### PR TITLE
Add xOBSE-compatible ref essential actor commands

### DIFF
--- a/obse64/CommandTable.cpp
+++ b/obse64/CommandTable.cpp
@@ -56,6 +56,17 @@ static CommandInfo kTestArgCommand =
 	HANDLER(Cmd_TestArgs_Execute)
 };
 
+static CommandInfo kPaddingCommand =
+{
+	"", "",
+	0,
+	"empty padding command",
+	0,
+	0, nullptr,
+
+	HANDLER(Cmd_Test_Execute)
+};
+
 void ImportConsoleCommand(const char * name)
 {
 	for(u32 i = 0; i < kScript_NumConsoleCommands; i++)
@@ -182,4 +193,9 @@ void AddScriptCommands()
 	ImportConsoleCommand("WaterReflectionColor");
 	ImportConsoleCommand("SetGamma");
 	ImportConsoleCommand("SetHDRParam");
+	// Match xOBSE opcodes: IsRefEssential = 0x1477, SetRefEssential = 0x1478.
+	for(u32 i = 0; i < 41; i++)
+		AddScriptCommand(kPaddingCommand);
+	ADD(IsRefEssential);
+	ADD(SetRefEssential);
 }

--- a/obse64/Commands_Actor.cpp
+++ b/obse64/Commands_Actor.cpp
@@ -1,0 +1,72 @@
+#include "GameScript.h"
+#include "GameForms.h"
+#include "GameObjects.h"
+#include "GameRTTI.h"
+#include "GameConsole.h"
+#include "ParamInfos.h"
+
+static TESActorBaseData * GetActorBaseData(TESObjectREFR * ref)
+{
+	if(!ref)
+		return nullptr;
+
+	TESForm * baseForm = ref->GetBaseForm();
+	if(!baseForm)
+		return nullptr;
+
+	return DYNAMIC_CAST(baseForm, TESForm, TESActorBaseData);
+}
+
+static bool Cmd_IsRefEssential_Execute(COMMAND_ARGS)
+{
+	*result = 0;
+
+	TESActorBaseData * actorBaseData = GetActorBaseData(thisObj);
+	if(actorBaseData)
+		*result = actorBaseData->IsEssential() ? 1 : 0;
+
+	if(IsConsoleMode())
+		Console_Print("IsRefEssential >> %.0f", *result);
+
+	return true;
+}
+
+static bool Cmd_SetRefEssential_Execute(COMMAND_ARGS)
+{
+	u32 setEssential = 0;
+	if(!ExtractArgs(EXTRACT_ARGS, &setEssential))
+		return true;
+
+	TESActorBaseData * actorBaseData = GetActorBaseData(thisObj);
+	if(actorBaseData)
+	{
+		actorBaseData->SetEssential(setEssential != 0);
+
+		if(IsConsoleMode())
+			Console_Print("SetRefEssential >> %d", setEssential != 0);
+	}
+
+	return true;
+}
+
+CommandInfo kCommandInfo_IsRefEssential =
+{
+	"IsRefEssential", "",
+	0,
+	"returns 1 if the calling actor reference's base is essential",
+	1,
+	0, nullptr,
+
+	Cmd_IsRefEssential_Execute,
+};
+
+CommandInfo kCommandInfo_SetRefEssential =
+{
+	"SetRefEssential", "",
+	0,
+	"sets or clears the essential flag on the calling actor reference's base",
+	1,
+	1, kParams_OneInt,
+
+	Cmd_SetRefEssential_Execute,
+};

--- a/obse64/GameForms.cpp
+++ b/obse64/GameForms.cpp
@@ -5,6 +5,18 @@
 
 RelocAddr <_LookupFormByID> LookupFormByID(0x066114B0);
 
+void TESActorBaseData::SetEssential(bool essential)
+{
+	if(essential)
+		flags |= kFlag_IsEssential;
+	else
+		flags &= ~kFlag_IsEssential;
+
+	TESForm * baseForm = DYNAMIC_CAST(this, TESActorBaseData, TESForm);
+	if(baseForm)
+		baseForm->MarkAsModified(kModified_ActorBaseFlags);
+}
+
 enum
 {
 	kSlot_Head = 0x1 << TESBipedModelForm::kPart_Head,

--- a/obse64/GameForms.h
+++ b/obse64/GameForms.h
@@ -41,6 +41,36 @@ public:
 
 static_assert(sizeof(BaseFormComponent) == 0x08);
 
+// 28
+class TESActorBaseData : public BaseFormComponent
+{
+public:
+	enum
+	{
+		kModified_ActorBaseFlags = 0x00000010,
+		kFlag_IsEssential = 0x00000002,
+	};
+
+	u32	flags;			// 08
+	u16	baseSpellPts;	// 0C
+	u16	fatigue;		// 0E
+	u16	barterGold;		// 10
+	s16	level;			// 12
+	u16	minLevel;		// 14
+	u16	maxLevel;		// 16
+	u32	unk18;			// 18
+	void * factionList;	// 20
+
+	bool IsEssential() const
+	{
+		return (flags & kFlag_IsEssential) != 0;
+	}
+
+	void SetEssential(bool essential);
+};
+
+static_assert(sizeof(TESActorBaseData) == 0x28);
+
 // 18
 class TESFullName : public BaseFormComponent
 {


### PR DESCRIPTION
Summary
-------
This adds two xOBSE actor commands that are useful for follower/protection mods:

- `IsRefEssential`
- `SetRefEssential`

Both commands operate on the calling actor reference's base actor data, matching
the classic xOBSE behavior. `SetRefEssential` updates the actor base essential
flag and marks the actor base flags as modified.

Implementation Notes
--------------------
- Adds a minimal `TESActorBaseData` component layout.
- Adds `TESActorBaseData::SetEssential`.
- Adds `Commands_Actor.cpp` with `IsRefEssential` and `SetRefEssential`.
- Registers the commands at the xOBSE-compatible opcodes:
  - `IsRefEssential`: `0x1477`
  - `SetRefEssential`: `0x1478`

Motivation
----------
OBSE64 currently implements a subset of classic OBSE/xOBSE functionality.
These commands are useful for mods that need to temporarily protect actor
references, such as follower frameworks that emulate Skyrim-style essential
followers.

Manual Test
-----------
Built successfully in Release with Visual Studio 2022/CMake.

Runtime behavior tested locally in Oblivion Remastered 1.512.105:

- `SetRefEssential 1` on a recruited NPC displays the essential crown and
  prevents death.
- `IsRefEssential` returns the expected value.
- `SetRefEssential 0` clears the essential state.

Follow-Up
---------
While porting a follower mod, `RestoreAV`/`RestoreActorValue` were also found
missing from the scripting environment. Those are not included here because they
belong to actor value command compatibility and should be handled in a separate
PR/issue.
