### PR TITLE
Add per-reference actor protection

### DIFF
--- a/obse64/CMakeLists.txt
+++ b/obse64/CMakeLists.txt
@@ -109,6 +109,8 @@ source_group(
 		Hooks_Gameplay.h
 		Hooks_Data.cpp
 		Hooks_Data.h
+		Hooks_RefProtection.cpp
+		Hooks_RefProtection.h
 )
 
 source_group(
@@ -130,6 +132,7 @@ source_group(
 source_group(
 	${PROJECT_NAME}/commands
 	FILES
+		Commands_Actor.cpp
 		Commands_Inventory.cpp
 		Commands_Input.cpp
 		Commands_Console.cpp

--- a/obse64/CommandTable.cpp
+++ b/obse64/CommandTable.cpp
@@ -182,4 +182,6 @@ void AddScriptCommands()
 	ImportConsoleCommand("WaterReflectionColor");
 	ImportConsoleCommand("SetGamma");
 	ImportConsoleCommand("SetHDRParam");
+	ADD(IsRefProtected);
+	ADD(SetRefProtected);
 }

--- a/obse64/Commands_Actor.cpp
+++ b/obse64/Commands_Actor.cpp
@@ -1,0 +1,66 @@
+#include "GameScript.h"
+#include "GameObjects.h"
+#include "GameRTTI.h"
+#include "GameConsole.h"
+#include "ParamInfos.h"
+#include "ProtectedRefRegistry.h"
+
+static bool IsActorRef(TESObjectREFR * ref)
+{
+	if(!ref)
+		return false;
+
+	return DYNAMIC_CAST(ref, TESObjectREFR, Actor) != nullptr;
+}
+
+static bool Cmd_IsRefProtected_Execute(COMMAND_ARGS)
+{
+	*result = 0;
+
+	if(IsActorRef(thisObj))
+		*result = ProtectedRefRegistry::Get().IsProtected(thisObj->refID) ? 1 : 0;
+
+	if(IsConsoleMode())
+		Console_Print("IsRefProtected >> %.0f", *result);
+
+	return true;
+}
+
+static bool Cmd_SetRefProtected_Execute(COMMAND_ARGS)
+{
+	u32 setProtected = 0;
+	if(!ExtractArgs(EXTRACT_ARGS, &setProtected))
+		return true;
+
+	if(IsActorRef(thisObj))
+	{
+		ProtectedRefRegistry::Get().SetProtected(thisObj->refID, setProtected != 0);
+
+		if(IsConsoleMode())
+			Console_Print("SetRefProtected >> %d", setProtected != 0);
+	}
+
+	return true;
+}
+
+CommandInfo kCommandInfo_IsRefProtected =
+{
+	"IsRefProtected", "",
+	0,
+	"returns 1 if the calling actor reference is protected",
+	1,
+	0, nullptr,
+
+	Cmd_IsRefProtected_Execute,
+};
+
+CommandInfo kCommandInfo_SetRefProtected =
+{
+	"SetRefProtected", "",
+	0,
+	"sets or clears per-reference actor protection",
+	1,
+	1, kParams_OneInt,
+
+	Cmd_SetRefProtected_Execute,
+};

--- a/obse64/Hooks_Data.cpp
+++ b/obse64/Hooks_Data.cpp
@@ -3,6 +3,7 @@
 #include "obse64_common/BranchTrampoline.h"
 #include "GameData.h"
 #include "PluginManager.h"
+#include "ProtectedRefRegistry.h"
 
 RelocAddr <uintptr_t> LoadingComplete_Hook(0x065D2070 + 0x9D2);
 
@@ -11,6 +12,7 @@ static void LoadingComplete()
 	CALL_MEMBER_FN(TESDataHandler::GetSingleton(), UnkInit)();
 
 	// before triggering starting cell
+	ProtectedRefRegistry::Get().Clear();
 	g_pluginManager.dispatchMessage(0, OBSEMessagingInterface::kMessage_DataLoaded, nullptr, 0, nullptr);
 }
 

--- a/obse64/Hooks_RefProtection.cpp
+++ b/obse64/Hooks_RefProtection.cpp
@@ -1,0 +1,131 @@
+#include "Hooks_RefProtection.h"
+#include "ProtectedRefRegistry.h"
+#include "RE_Offsets.h"
+#include "obse64_common/BranchTrampoline.h"
+#include "obse64_common/Log.h"
+#include "obse64_common/Relocation.h"
+#include "obse64_common/SafeWrite.h"
+#include "xbyak/xbyak.h"
+
+namespace
+{
+	bool IsProtectedActor(void * actor)
+	{
+		if(!actor)
+			return false;
+
+		auto formID = *reinterpret_cast<u32 *>(reinterpret_cast<uintptr_t>(actor) + RE::RefProtection::kActorFormIDOffset);
+		return ProtectedRefRegistry::Get().IsProtected(formID);
+	}
+
+	class DeathGuardHookCode : public Xbyak::CodeGenerator
+	{
+	public:
+		DeathGuardHookCode(void * buf, uintptr_t isProtectedActor, uintptr_t nativeIsEssential, uintptr_t deathPath, uintptr_t essentialPath)
+			: Xbyak::CodeGenerator(256, buf)
+		{
+			// RSI is the victim Actor* at this guard.
+			mov(rcx, rsi);
+			mov(rax, isProtectedActor);
+			call(rax);
+
+			test(al, al);
+			jnz("essentialPath");
+
+			mov(rcx, rsi);
+			mov(rax, nativeIsEssential);
+			call(rax);
+
+			test(al, al);
+			jz("deathPath");
+
+			L("essentialPath");
+			mov(rax, essentialPath);
+			jmp(rax);
+
+			L("deathPath");
+			mov(rax, deathPath);
+			jmp(rax);
+		}
+	};
+
+	class CrosshairIconHookCode : public Xbyak::CodeGenerator
+	{
+	public:
+		CrosshairIconHookCode(void * buf, uintptr_t isProtectedActor, uintptr_t nativeIsEssential, uintptr_t normalReturn, uintptr_t essentialReturn)
+			: Xbyak::CodeGenerator(256, buf)
+		{
+			// RBX is the target Actor* for this crosshair icon query.
+			mov(rcx, rbx);
+			mov(rax, isProtectedActor);
+			call(rax);
+
+			test(al, al);
+			jnz("essentialReturn");
+
+			test(rbx, rbx);
+			jz("normalReturn");
+
+			mov(rcx, rbx);
+			mov(rax, nativeIsEssential);
+			call(rax);
+
+			test(al, al);
+			jz("normalReturn");
+
+			L("essentialReturn");
+			mov(rax, essentialReturn);
+			jmp(rax);
+
+			L("normalReturn");
+			mov(rax, normalReturn);
+			jmp(rax);
+		}
+	};
+
+	void InstallDeathGuardHook()
+	{
+		uintptr_t hookSite = RelocationManager::s_baseAddr + RE::RefProtection::kDeathGuardHookRVA;
+		uintptr_t nativeIsEssential = RelocationManager::s_baseAddr + RE::RefProtection::kNativeIsEssentialRVA;
+		uintptr_t deathPath = RelocationManager::s_baseAddr + RE::RefProtection::kDeathGuardDeathPathRVA;
+		uintptr_t essentialPath = RelocationManager::s_baseAddr + RE::RefProtection::kDeathGuardEssentialFallthroughRVA;
+
+		void * codeBuf = g_localTrampoline.startAlloc();
+		DeathGuardHookCode code(codeBuf, uintptr_t(&IsProtectedActor), nativeIsEssential, deathPath, essentialPath);
+		code.ready();
+		g_localTrampoline.endAlloc(code.getCurr());
+
+		g_branchTrampoline.write5Branch(hookSite, uintptr_t(codeBuf));
+
+		for(u32 i = 5; i < RE::RefProtection::kDeathGuardPatchSize; i++)
+			safeWrite8(hookSite + i, 0x90);
+
+		_MESSAGE("ref protection death guard hook installed at %016I64X", hookSite);
+	}
+
+	void InstallCrosshairIconHook()
+	{
+		uintptr_t hookSite = RelocationManager::s_baseAddr + RE::RefProtection::kCrosshairIconHookRVA;
+		uintptr_t nativeIsEssential = RelocationManager::s_baseAddr + RE::RefProtection::kNativeIsEssentialRVA;
+		uintptr_t normalReturn = RelocationManager::s_baseAddr + RE::RefProtection::kCrosshairIconNormalReturnRVA;
+		uintptr_t essentialReturn = RelocationManager::s_baseAddr + RE::RefProtection::kCrosshairIconEssentialReturnRVA;
+
+		void * codeBuf = g_localTrampoline.startAlloc();
+		CrosshairIconHookCode code(codeBuf, uintptr_t(&IsProtectedActor), nativeIsEssential, normalReturn, essentialReturn);
+		code.ready();
+		g_localTrampoline.endAlloc(code.getCurr());
+
+		g_branchTrampoline.write5Branch(hookSite, uintptr_t(codeBuf));
+
+		for(u32 i = 5; i < RE::RefProtection::kCrosshairIconPatchSize; i++)
+			safeWrite8(hookSite + i, 0x90);
+
+		_MESSAGE("ref protection crosshair icon hook installed at %016I64X", hookSite);
+	}
+}
+
+void Hooks_RefProtection_Apply()
+{
+	InstallDeathGuardHook();
+	InstallCrosshairIconHook();
+}

--- a/obse64/Hooks_RefProtection.h
+++ b/obse64/Hooks_RefProtection.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void Hooks_RefProtection_Apply();

--- a/obse64/ProtectedRefRegistry.cpp
+++ b/obse64/ProtectedRefRegistry.cpp
@@ -1,0 +1,35 @@
+#include "ProtectedRefRegistry.h"
+
+ProtectedRefRegistry & ProtectedRefRegistry::Get()
+{
+	static ProtectedRefRegistry s_registry;
+	return s_registry;
+}
+
+void ProtectedRefRegistry::SetProtected(u32 formID, bool protect)
+{
+	if(!formID)
+		return;
+
+	std::lock_guard<std::mutex> lock(m_mutex);
+
+	if(protect)
+		m_refs.insert(formID);
+	else
+		m_refs.erase(formID);
+}
+
+bool ProtectedRefRegistry::IsProtected(u32 formID) const
+{
+	if(!formID)
+		return false;
+
+	std::lock_guard<std::mutex> lock(m_mutex);
+	return m_refs.find(formID) != m_refs.end();
+}
+
+void ProtectedRefRegistry::Clear()
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	m_refs.clear();
+}

--- a/obse64/ProtectedRefRegistry.h
+++ b/obse64/ProtectedRefRegistry.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "obse64_common/Types.h"
+#include <mutex>
+#include <unordered_set>
+
+class ProtectedRefRegistry
+{
+public:
+	static ProtectedRefRegistry & Get();
+
+	void SetProtected(u32 formID, bool protect);
+	bool IsProtected(u32 formID) const;
+	void Clear();
+
+private:
+	ProtectedRefRegistry() = default;
+
+	mutable std::mutex m_mutex;
+	std::unordered_set<u32> m_refs;
+};

--- a/obse64/RE_Offsets.h
+++ b/obse64/RE_Offsets.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "obse64_common/Types.h"
+
+namespace RE
+{
+	namespace RefProtection
+	{
+		// Local RVAs confirmed against Oblivion Remastered 1.512.105.
+		// TODO(RE): Convert these to address-library IDs if required upstream.
+		constexpr uintptr_t kDeathGuardHookRVA = 0x065B9538;
+		constexpr uintptr_t kDeathGuardDeathPathRVA = 0x065B99D3;
+		constexpr uintptr_t kDeathGuardEssentialFallthroughRVA = 0x065B9548;
+		constexpr uintptr_t kNativeIsEssentialRVA = 0x065B0D10;
+		constexpr u32 kDeathGuardPatchSize = 0x10;
+
+		constexpr uintptr_t kCrosshairIconHookRVA = 0x06580616;
+		constexpr uintptr_t kCrosshairIconNormalReturnRVA = 0x06580705;
+		constexpr uintptr_t kCrosshairIconEssentialReturnRVA = 0x0658062F;
+		constexpr u32 kCrosshairIconPatchSize = 0x19;
+
+		constexpr u32 kActorFormIDOffset = 0x10;
+	}
+}

--- a/obse64/obse64.cpp
+++ b/obse64/obse64.cpp
@@ -17,6 +17,7 @@
 #include "Hooks_Version.h"
 #include "Hooks_Gameplay.h"
 #include "Hooks_Data.h"
+#include "Hooks_RefProtection.h"
 
 HINSTANCE g_moduleHandle = nullptr;
 
@@ -155,6 +156,7 @@ void OBSE64_Initialize()
 	Hooks_Version_Apply();
 	Hooks_Gameplay_Apply();
 	Hooks_Data_Apply();
+	Hooks_RefProtection_Apply();
 
 	FlushInstructionCache(GetCurrentProcess(), NULL, 0);
 


### PR DESCRIPTION
## Summary

This is a fresh approach after closing the previous `SetRefEssential` PR.

The previous PR tried to port classic xOBSE `SetRefEssential` behavior by adding a partial actor base data layout. That was the wrong direction for OBSE64, because it depended on an unverified structure definition.

This PR does not add or use a `TESActorBaseData` layout, does not modify actor base flags, and does not change `SetRefEssential`.

Instead, it adds a separate per-reference protection system:

```text
IsRefProtected
SetRefProtected
```

Protected state is stored by reference FormID in a runtime registry. The engine is only redirected at two reverse-engineered vanilla decision points:

```text
1. lethal death decision;
2. crosshair essential icon decision.
```

The goal is to let scripts protect a specific actor reference without making every reference using the same base actor essential.

## Reverse engineering work

### Tools / methodology

The reverse engineering pass was done with:

```text
Ghidra    -> static analysis, xrefs, decompilation, and control-flow inspection
x64dbg    -> runtime breakpoints, register validation, branch validation
in-game tests -> behavior validation with vanilla essential actors and duplicate same-BaseID refs
```

The workflow was:

```text
1. identify candidate native functions and branches in Ghidra;
2. set x64dbg breakpoints on the candidate RVAs;
3. compare runtime state for vanilla essential and non-essential actors;
4. validate which register contained the Actor* at each hook site;
5. test protected vs unprotected refs sharing the same BaseID in game.
```

The patch only uses callsites that were validated both statically and at runtime.

### Native essential query

The native essential query used by the engine was identified as:

```text
FUN_1465b0d10
RVA 0x065B0D10
```

Runtime observations:

```text
non-essential actor -> AL = 0
essential actor     -> AL = 1
```

This function is treated as an opaque native query by the patch. The PR does not reimplement its layout assumptions.

### Death decision

The lethal death decision was identified in:

```text
FUN_1465b94b0
```

Relevant block:

```asm
1465b9538  MOV  RCX, RSI
1465b953B  CALL FUN_1465b0d10
1465b9540  TEST AL, AL
1465b9542  JZ   LAB_1465b99d3
```

Runtime validation:

```text
non-essential actor:
    AL = 0
    JZ taken
    normal death path

essential actor:
    AL = 1
    JZ not taken
    EssentialCharacterDown path
```

Hook site:

```text
RVA 0x065B9538
```

At this site, `RSI` was confirmed as the victim actor pointer. The hook checks the protected-ref registry first. If the reference is protected, it jumps to the same vanilla fallthrough used by essential actors. Otherwise it replays the displaced vanilla `IsEssential` call and branches to the original destinations.

### Crosshair essential icon decision

The crosshair target icon decision was identified in:

```text
FUN_146580460
```

Relevant block:

```asm
06580616  TEST RBX, RBX
06580619  JZ   06580705
0658061F  MOV  RCX, RBX
06580622  CALL 065B0D10
06580627  TEST AL, AL
06580629  JZ   06580705
0658062F  MOV  EAX, 0A
```

Runtime observations:

```text
0xA -> essential/crown target icon
0x7 -> normal actor target icon
```

Runtime validation:

```text
vanilla essential actor -> returns 0xA
normal actor            -> returns 0x7
protected actor ref     -> returns 0xA after this hook
unprotected same-BaseID ref -> returns 0x7
```

Hook site:

```text
RVA 0x06580616
```

At this site, `RBX` was confirmed as the target actor pointer. The hook only affects this icon decision and does not draw or replace UI manually.

## Implementation

The patch adds:

```text
ProtectedRefRegistry
Commands_Actor.cpp
Hooks_RefProtection.cpp
RE_Offsets.h
```

Command behavior:

```text
SetRefProtected 1 -> add calling actor refID to the runtime registry
SetRefProtected 0 -> remove calling actor refID from the runtime registry
IsRefProtected    -> return whether calling actor refID is currently protected
```

The registry is cleared on `DataLoaded`, before the data-loaded message is dispatched. This keeps the protected state runtime-only and avoids stale protected refs when loading another save in the same process. Mods that want persistence should reapply `SetRefProtected` after load.

## Design constraints

This intentionally does not:

```text
modify ActorBase essential flags;
add a TESActorBaseData layout;
hook IsEssential globally;
persist protected refs inside OBSE64;
draw or replace UI manually;
change SetRefEssential behavior;
claim xOBSE opcode compatibility.
```

The hooks are limited to the two vanilla decision points above.

## Runtime notes

The RVAs in `RE_Offsets.h` are confirmed against Oblivion Remastered 1.512.105.

I kept them isolated in `RE_Offsets.h` so they can be converted to address-library IDs or updated more easily if that is preferred.

## Tested behavior

Tested with two actor references sharing the same BaseID:

```text
protected ref:
    enters EssentialCharacterDown instead of dying;
    recovers through the vanilla path;
    shows the essential crown at the crosshair.

unprotected same-BaseID ref:
    dies normally;
    does not show the crown.
```

Also verified:

```text
vanilla essential actors still show the crown;
normal actors keep the normal target icon;
protected state does not survive a full process restart unless reapplied by script;
the actor base Essential flag is not changed.
```

I'd be interested in your thoughts on whether this is a more appropriate direction for OBSE64, especially around the hook sites and whether you would prefer these RVAs to be handled differently.
